### PR TITLE
fix mistake with always missing branch rule for workflow editing

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,7 +1,7 @@
 name: Doxygen
 
 on:
-  pull_request:
+  push:
     branches: ["main"]
 
 permissions:


### PR DESCRIPTION
Из-за этого недочета при каждом пул реквесте приходится добавлять ветку в разрешенные на запуск workflow, иначе пул реквест невозможно принять
Теперь, когда это происходит на push в main: сначала принимается пул реквест, мерджится, а только потом запускается workflow (и не нужно лишний раз никуда добавлять ветку)